### PR TITLE
Fix rankings loading from data folder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,8 +65,15 @@
       Powered by Fatals.net
     </footer>
     <script>
+      function getQueryParam(name) {
+        const params = new URLSearchParams(window.location.search);
+        return params.get(name);
+      }
+
       async function fetchRankings() {
-        const res = await fetch(`/api/rankings`);
+        const leagueId = getQueryParam('leagueId');
+        const qs = leagueId ? `?leagueId=${encodeURIComponent(leagueId)}` : '';
+        const res = await fetch(`/api/rankings${qs}`);
         if (!res.ok) throw new Error('Failed to load rankings');
         return res.json();
       }

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,7 @@
     }
   },
   "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/", "destination": "/public/index.html" },
     { "source": "/(.*)", "destination": "/public/$1" }
   ]


### PR DESCRIPTION
Fix Vercel API routing and pass `leagueId` from URL to the rankings API.

The "Failed to load rankings" error occurred because Vercel's rewrite rules were incorrectly routing `/api/*` requests to static files, and the frontend was not forwarding the `leagueId` query parameter to the API endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8eb7ae5-baf9-4832-ab34-a2b25e2bd1bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8eb7ae5-baf9-4832-ab34-a2b25e2bd1bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

